### PR TITLE
deprecate from_host, to_host

### DIFF
--- a/include/ttl/bits/std_tensor_mixin.hpp
+++ b/include/ttl/bits/std_tensor_mixin.hpp
@@ -40,16 +40,6 @@ class basic_scalar_mixin
     data_ptr data_end() const { return data_.get() + 1; }
 
     S shape() const { return S(); }
-
-    void from_host(const void *data) const
-    {
-        basic_copier<D, host_memory>()(data_.get(), data, data_size());
-    }
-
-    void to_host(void *data) const
-    {
-        basic_copier<host_memory, D>()(data, data_.get(), data_size());
-    }
 };
 
 template <typename R, typename S, typename D, typename A>
@@ -157,16 +147,6 @@ class basic_tensor_mixin
         const auto sub_shape = shape_.subshape();
         return slice_type(data_.get() + i * sub_shape.size(),
                           batch(j - i, sub_shape));
-    }
-
-    void from_host(const void *data) const
-    {
-        basic_copier<D, host_memory>()(data_.get(), data, data_size());
-    }
-
-    void to_host(void *data) const
-    {
-        basic_copier<host_memory, D>()(data, data_.get(), data_size());
     }
 };
 }  // namespace internal

--- a/tests/bench_cuda_tensor.cpp
+++ b/tests/bench_cuda_tensor.cpp
@@ -1,16 +1,18 @@
 #include "benchmark.hpp"
 
 #include <ttl/cuda_tensor>
+#include <ttl/experimental/copy>
 
-template <typename R, int n> struct bench_cuda_tensor {
+template <typename R, int n>
+struct bench_cuda_tensor {
     static void run(benchmark::State &state)
     {
         ttl::cuda_tensor<R, 1> m1(n);
         ttl::tensor<R, 1> m2(n);
 
         for (auto _ : state) {
-            m1.from_host(m2.data());
-            m1.to_host(m2.data());
+            ttl::copy(ttl::ref(m1), ttl::view(m2));
+            ttl::copy(ttl::ref(m2), ttl::view(m1));
         }
     }
 };


### PR DESCRIPTION
should use `ttl::copy` instead